### PR TITLE
Refactor of torch tests

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -28,6 +28,7 @@ install:
   - if [[ "x$QLIC_KC" != "x" ]]; then
       echo -n $QLIC_KC |base64 --decode > q/kc.lic;
       pip -q install -r requirements.txt;
+      pip install torch;
       pip install gensim;
       pip install sobol-seq;
 

--- a/build/test.bat
+++ b/build/test.bat
@@ -7,6 +7,7 @@ if defined QLIC_KC (
 	python -m spacy download en
 	pip install gensim
 	pip install sobol-seq
+        pip install pytorch
         curl -fsSL -o test.q https://github.com/KxSystems/embedpy/raw/master/test.q
         q test.q -q
 )

--- a/tests/torch.t
+++ b/tests/torch.t
@@ -1,49 +1,68 @@
-\l automl.q
 \d .automl
+\l automl.q
 
+// load the library to retrieve checkimport function
 loadfile`:init.q
 
-if[0~checkimport[1];
 
-  // check pytorch models if pytorch installed
+// don't run tests if torch can't be loaded
+if[not 0~checkimport[1];exit 0];
 
-  // Replace the defaults with an example containing torch
-  og2tst:(("/code/models/lib_support/torch.q";"/code/models/lib_support/oldtorch.q");("/code/models/lib_support/torch.p";"/code/models/lib_support/oldtorch.p");("/code/models/models/classmodels.txt";"/code/models/models/oldclassmodels.txt");("/tests/files/torch.q";"/code/models/lib_support/");("/tests/files/torch.p";"/code/models/lib_support/");("/tests/files/classmodels.txt";"/code/models/models/classmodels.txt"));
-  og2tst:{" "sv x,/:y}[path]each og2tst;
-  system"c 1000 1000";
-  $[w:"w"=string[.z.o]0;{system"move ",ssr[x;"/";"\\"]};{system"mv ",x}]each og2tst;
 
-  // Run tests to ensure nothing is failing when running with only a pytorch model
+// generate data for testing
+tgt_f  :asc 100?1f;
+tgt_b  :100?0b;
+tgt_mul:100?3;
+normtab1:([]100?1f;100?0b;asc 100?`1;100?100);
+normtab2:([]100?0Ng;100?1f;asc 100?1000;100?`1);
+freshtab1:([]5000?100?0p;asc 5000?100?1f;5000?1f;desc 5000?10f;5000?0b);
+freshtab2:([]5000?100?0p;5000?0Ng;desc 5000?1f;asc 5000?1f;5000?`1);
 
-  tgt_f  :asc 100?1f;
-  tgt_b  :100?0b;
-  tgt_mul:100?3;
-  normtab1:([]100?1f;100?0b;asc 100?`1;100?100);
 
-  $[(::)~@[{.automl.run[x;tgt_f  ;`normal;`reg  ;::];};normtab1;{[err]err;0b}];1b;0b];
-  $[(::)~@[{.automl.run[x;tgt_b  ;`normal;`class;::];};normtab1;{[err]err;0b}];1b;0b];
-  $[(::)~@[{.automl.run[x;tgt_mul;`normal;`class;::];};normtab1;{[err]err;0b}];1b;0b];
+// language agnostic function for moving a file to a new location
+moveFiles:{[filePaths]
+  os:.z.o like "w*";
+  filePaths:{" "sv raze each x,/:y}[.automl.path;filePaths];
+  if[os;filePaths:ssr[filePaths;"/";"\\"]];
+  system $[os;"move ";"mv "],filePaths;
+  }
+
+
+// file paths to allow torch model tests to be added and reverted to original
+filePaths:(("/code/models/lib_support/torch.q";"/code/models/lib_support/oldtorch.q");
+          ("/code/models/lib_support/torch.p";"/code/models/lib_support/oldtorch.p");
+          ("/code/models/models/classmodels.txt";"/code/models/models/oldclassmodels.txt");
+          ("/tests/files/torch.q";"/code/models/lib_support/torch.q");
+          ("/tests/files/torch.p";"/code/models/lib_support/torch.p");
+          ("/tests/files/classmodels.txt";"/code/models/models/classmodels.txt"));
+
+moveFiles each filePaths;
+
+// reload the library contents to ensure the correct torch files used
+loadfile`:init.q
+
+// Run tests to ensure nothing is failing when running with only a pytorch model
+
+$[(::)~@[{.automl.run[x;tgt_f  ;`normal;`reg  ;::];};normtab1;{[err]err;0b}];1b;0b]
+$[(::)~@[{.automl.run[x;tgt_b  ;`normal;`class;::];};normtab1;{[err]err;0b}];1b;0b]
+$[(::)~@[{.automl.run[x;tgt_mul;`normal;`class;::];};normtab1;{[err]err;0b}];1b;0b]
+
+$[(::)~@[{.automl.run[x;tgt_f  ;`normal;`reg  ;::];};normtab2;{[err]err;0b}];1b;0b]
+$[(::)~@[{.automl.run[x;tgt_b  ;`normal;`class;::];};normtab2;{[err]err;0b}];1b;0b]
+$[(::)~@[{.automl.run[x;tgt_mul;`normal;`class;::];};normtab2;{[err]err;0b}];1b;0b]
+
+$[(::)~@[{.automl.run[x;tgt_f  ;`fresh;`reg  ;::];};freshtab1;{[err]err;0b}];1b;0b]
+$[(::)~@[{.automl.run[x;tgt_b  ;`fresh;`class;::];};freshtab1;{[err]err;0b}];1b;0b]
+$[(::)~@[{.automl.run[x;tgt_mul;`fresh;`class;::];};freshtab1;{[err]err;0b}];1b;0b]
   
-  normtab2:([]100?0Ng;100?1f;asc 100?1000;100?`1);
+$[(::)~@[{.automl.run[x;tgt_f  ;`fresh;`reg  ;::];};freshtab2;{[err]err;0b}];1b;0b]
+$[(::)~@[{.automl.run[x;tgt_b  ;`fresh;`class;::];};freshtab2;{[err]err;0b}];1b;0b]
+$[(::)~@[{.automl.run[x;tgt_mul;`fresh;`class;::];};freshtab2;{[err]err;0b}];1b;0b]
 
-  $[(::)~@[{.automl.run[x;tgt_f  ;`normal;`reg  ;::];};normtab2;{[err]err;0b}];1b;0b];
-  $[(::)~@[{.automl.run[x;tgt_b  ;`normal;`class;::];};normtab2;{[err]err;0b}];1b;0b];
-  $[(::)~@[{.automl.run[x;tgt_mul;`normal;`class;::];};normtab2;{[err]err;0b}];1b;0b];
-  
-  freshtab1:([]5000?100?0p;asc 5000?100?1f;5000?1f;desc 5000?10f;5000?0b);
 
-  $[(::)~@[{.automl.run[x;tgt_f  ;`fresh;`reg  ;::];};freshtab1;{[err]err;0b}];1b;0b];
-  $[(::)~@[{.automl.run[x;tgt_b  ;`fresh;`class;::];};freshtab1;{[err]err;0b}];1b;0b];
-  $[(::)~@[{.automl.run[x;tgt_mul;`fresh;`class;::];};freshtab1;{[err]err;0b}];1b;0b];
-  
-  freshtab2:([]5000?100?0p;5000?0Ng;desc 5000?1f;asc 5000?1f;5000?`1);
+// Revert to the default torch setup
+moveFiles each reverse each filePaths rotate[3;til 6];
 
-  $[(::)~@[{.automl.run[x;tgt_f  ;`fresh;`reg  ;::];};freshtab2;{[err]err;0b}];1b;0b];
-  $[(::)~@[{.automl.run[x;tgt_b  ;`fresh;`class;::];};freshtab2;{[err]err;0b}];1b;0b];
-  $[(::)~@[{.automl.run[x;tgt_mul;`fresh;`class;::];};freshtab2;{[err]err;0b}];1b;0b];
+// Revert the automl library version to use 
+loadfile`:init.q
 
-  // Revert to the default torch setup
-  tst2og:(("/code/models/lib_support/torch.q";"/tests/files/");("/code/models/lib_support/torch.p";"/tests/files/");("/code/models/models/classmodels.txt";"/tests/files/");("/code/models/lib_support/oldtorch.q";"/code/models/lib_support/torch.q");("/code/models/lib_support/oldtorch.p";"/code/models/lib_support/torch.p");("/code/models/models/oldclassmodels.txt";"/code/models/models/classmodels.txt"));
-  tst2og:{" "sv x,/:y}[path]each tst2og;
-  $[w;{system"move ",ssr[x;"/";"\\"]};{system"mv ",x}]each tst2og;
-  ]


### PR DESCRIPTION
Tests would fail to run correctly for the following reasons
* torch not installed on `.travis.yml`
* 'moving' the files with torch model defined but not reloading the automl library means changes to the .q and .p files wouldn't be caught in the code and `.automl.torchmdl` wouldn't be defined.
* This wasn't getting seen because large if statement for running when torch is installed doesn't give any indication that a failure has occurred (this is why the checkimport is at the top and the large if statement removed).

Some minor updates for code cleanliness.
* Since you move files in one direction and just want to do the reverse in a different order you don't need to rewrite all the paths, just finish the absolute paths (explicitly state you're writing torch.q to torch.q), change the ordering (`rotate[3;x]`) and reverse each pair to get the return paths